### PR TITLE
Patch for Node 0.6.x support

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Tim Caswell <tim@creationix.com>",
   "name": "topcube",
   "description": "Simple bindings to create a webkit window that node can control",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "repository": {
     "type": "git",
     "url": "git://github.com/creationix/topcube.git"
@@ -10,6 +10,9 @@
   "main": "./topcube.js",
   "dependencies": {},
   "devDependencies": {},
+  "engines": {
+    "node": "<0.7.x"
+  },
   "scripts": {
     "preinstall": "node package.js"
   }

--- a/topcube.js
+++ b/topcube.js
@@ -14,7 +14,7 @@ module.exports = function (options) {
         keys = ['url', 'name', 'width', 'height', 'minwidth', 'minheight', 'ico', 'cache-path'];
         break;
     case 'linux':
-        client = path.resolve(__dirname + '/build/default/topcube');
+        client = path.resolve(__dirname + (/0\.4\./.test(process.version) ? '/build/default/topcube' : '/build/Release/topcube'));
         keys = ['url', 'name', 'width', 'height', 'minwidth', 'minheight'];
         break;
     default:


### PR DESCRIPTION
I wrote a simple patch for topcube to work on both Node 0.4.x and 0.6.x, solving Issue #5. This merely checks which version is in use and swaps between `default` and `Release` for the path to launch the topcube executable.

I figure [node-gyp](https://github.com/TooTallNate/node-gyp) support can come when Node 0.8 is nearly ready and node-waf is no longer supported at all.
