### PR TITLE
Expose 'log-file' option and add auto-tools like build wrappers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+build:
+	node-waf build
+
+.PHONY: build

--- a/configure
+++ b/configure
@@ -1,0 +1,2 @@
+#!/bin/sh
+node-waf configure

--- a/topcube.js
+++ b/topcube.js
@@ -11,7 +11,7 @@ module.exports = function (options) {
     switch (process.platform) {
     case 'win32':
         client = path.resolve(__dirname + '/cefclient/cefclient');
-        keys = ['url', 'name', 'width', 'height', 'minwidth', 'minheight', 'ico', 'cache-path'];
+        keys = ['url', 'name', 'width', 'height', 'minwidth', 'minheight', 'ico', 'cache-path', 'log-file'];
         break;
     case 'linux':
         client = path.resolve(__dirname + '/build/default/topcube');


### PR DESCRIPTION
- 'log-file' can be used to direct the cefclient (used on windows) to place its log file somewhere other than `%CD%\debug.log`
- The build wrappers are a convenience, as a variety of other node addons I maintain use them as well, so it makes it easier to automate builds scripts. 
